### PR TITLE
fix: add missing properties to magic link field

### DIFF
--- a/vika/types/field.py
+++ b/vika/types/field.py
@@ -124,6 +124,8 @@ class LastModifiedTimeFieldProperty(DateTimeFieldProperty):
 class MagicLinkFieldProperty(BaseModel):
     foreignDatasheetId: str
     brotherFieldId: Optional[str] = ""  # 字表关联没有兄弟字段
+    limitToViewId: Optional[str]
+    limitSingleRecord: bool
 
 
 class FieldPropertyWithDstId(BaseModel):


### PR DESCRIPTION
Add two missing properties `limitToViewId` and `limitSingleRecord` to MagicLink field as is documented in [the api reference](https://vika.cn/developers/api/reference/#magiclink%EF%BC%88%E7%A5%9E%E5%A5%87%E5%85%B3%E8%81%94%EF%BC%89).