### PR TITLE
fix: make `limitSingleRecord` property of magic link field optional

### DIFF
--- a/vika/types/field.py
+++ b/vika/types/field.py
@@ -125,7 +125,7 @@ class MagicLinkFieldProperty(BaseModel):
     foreignDatasheetId: str
     brotherFieldId: Optional[str] = ""  # 字表关联没有兄弟字段
     limitToViewId: Optional[str]
-    limitSingleRecord: bool
+    limitSingleRecord: Optional[bool]
 
 
 class FieldPropertyWithDstId(BaseModel):


### PR DESCRIPTION
`limitSingleRecord` should be an optional property of magic link field, this PR ensures that and prevents errors when it does not exist